### PR TITLE
Add uses-feature checks

### DIFF
--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/BaselineHandler.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/BaselineHandler.kt
@@ -1,6 +1,7 @@
 package io.github.simonschiller.permissioncheck.internal
 
 import io.github.simonschiller.permissioncheck.internal.data.BasePermission
+import io.github.simonschiller.permissioncheck.internal.data.Feature
 import io.github.simonschiller.permissioncheck.internal.data.Permission
 import io.github.simonschiller.permissioncheck.internal.data.Sdk23Permission
 import io.github.simonschiller.permissioncheck.internal.util.appendElement
@@ -76,6 +77,13 @@ internal class BaselineHandler(private val baselineFile: File) {
                 val name = element.getAttribute("name")
                 val maxSdkVersion = element.getAttribute("maxSdkVersion").toIntOrNull()
                 variantPermissions += Sdk23Permission(name, maxSdkVersion)
+            }
+
+            val features = variant.getElementsByTagName("uses-feature")
+            features.forEach { element ->
+                val name = element.getAttribute("name")
+                val required = element.getAttribute("required").toBooleanStrictOrNull()
+                variantPermissions += Feature(name, required)
             }
 
             permissions[variantName] = variantPermissions

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/ManifestParser.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/ManifestParser.kt
@@ -1,10 +1,12 @@
 package io.github.simonschiller.permissioncheck.internal
 
 import io.github.simonschiller.permissioncheck.internal.data.BasePermission
+import io.github.simonschiller.permissioncheck.internal.data.Feature
 import io.github.simonschiller.permissioncheck.internal.data.Permission
 import io.github.simonschiller.permissioncheck.internal.data.Sdk23Permission
 import io.github.simonschiller.permissioncheck.internal.util.createDocumentBuilder
 import io.github.simonschiller.permissioncheck.internal.util.forEach
+import org.w3c.dom.Document
 import java.io.File
 
 internal class ManifestParser {
@@ -15,21 +17,37 @@ internal class ManifestParser {
         val document = createDocumentBuilder().parse(manifest)
 
         // Parse regular permissions
-        val regularPermissions = document.getElementsByTagName("uses-permission")
-        regularPermissions.forEach { element ->
-            val name = element.getAttributeNS(namespace, "name")
-            val maxSdkVersion = element.getAttributeNS(namespace, "maxSdkVersion").toIntOrNull()
-            permissions += Permission(name, maxSdkVersion)
+        permissions += parseNodes(document, "uses-permission").map { node ->
+            Permission(node.name, node.maxSdkVersion)
         }
 
         // Parse SDK 23 permissions
-        val sdk23Permissions = document.getElementsByTagName("uses-permission-sdk-23")
-        sdk23Permissions.forEach { element ->
-            val name = element.getAttributeNS(namespace, "name")
-            val maxSdkVersion = element.getAttributeNS(namespace, "maxSdkVersion").toIntOrNull()
-            permissions += Sdk23Permission(name, maxSdkVersion)
+        permissions += parseNodes(document, "uses-permission-sdk-23").map { node ->
+            Sdk23Permission(node.name, node.maxSdkVersion)
+        }
+
+        // Parse features
+        permissions += parseNodes(document, "uses-feature").map { node ->
+            Feature(node.name, node.required)
         }
 
         return permissions
     }
+
+    private fun parseNodes(
+        document: Document,
+        tagName: String,
+    ): Set<Node> {
+        val nodes = mutableSetOf<Node>()
+        val regularPermissions = document.getElementsByTagName(tagName)
+        regularPermissions.forEach { element ->
+            val name = element.getAttributeNS(namespace, "name")
+            val maxSdkVersion = element.getAttributeNS(namespace, "maxSdkVersion").toIntOrNull()
+            val required = element.getAttributeNS(namespace, "required").toBooleanStrictOrNull()
+            nodes += Node(name, maxSdkVersion, required)
+        }
+        return nodes.toSet()
+    }
+
+    data class Node(val name: String, val maxSdkVersion: Int?, val required: Boolean?)
 }

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/data/Permissions.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/data/Permissions.kt
@@ -4,7 +4,7 @@ import org.w3c.dom.Document
 import org.w3c.dom.Element
 import java.util.*
 
-internal abstract class BasePermission(val name: String, val maxSdkVersion: Int?) : Comparable<BasePermission> {
+internal abstract class BasePermission(val name: String, val maxSdkVersion: Int?, val required: Boolean?) : Comparable<BasePermission> {
     abstract val tag: String
 
     fun toXmlElement(document: Document): Element = document.createElement(tag).apply {
@@ -12,14 +12,20 @@ internal abstract class BasePermission(val name: String, val maxSdkVersion: Int?
         if (maxSdkVersion != null) {
             setAttribute("maxSdkVersion", maxSdkVersion.toString())
         }
+        if (required != null) {
+            setAttribute("required", required.toString())
+        }
     }
 
-    abstract fun copy(name: String = this.name, maxSdkVersion: Int? = this.maxSdkVersion): BasePermission
+    abstract fun copy(name: String = this.name, maxSdkVersion: Int? = this.maxSdkVersion, required: Boolean?): BasePermission
 
     override fun toString(): String {
         val builder = StringBuilder("""<$tag android:name="$name" """)
         if (maxSdkVersion != null) {
             builder.append("""android:maxSdkVersion="$maxSdkVersion" """)
+        }
+        if (required != null) {
+            builder.append("""android:required="$required" """)
         }
         return builder.append("/>").toString()
     }
@@ -27,11 +33,11 @@ internal abstract class BasePermission(val name: String, val maxSdkVersion: Int?
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is BasePermission) return false
-        return name == other.name && maxSdkVersion == other.maxSdkVersion && tag == other.tag
+        return name == other.name && maxSdkVersion == other.maxSdkVersion && required == other.required && tag == other.tag
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(name, maxSdkVersion, tag)
+        return Objects.hash(name, maxSdkVersion, required, tag)
     }
 
     override fun compareTo(other: BasePermission): Int {
@@ -43,12 +49,17 @@ internal abstract class BasePermission(val name: String, val maxSdkVersion: Int?
     }
 }
 
-internal class Permission(name: String, maxSdkVersion: Int? = null) : BasePermission(name, maxSdkVersion) {
+internal class Permission(name: String, maxSdkVersion: Int? = null) : BasePermission(name, maxSdkVersion, null) {
     override val tag: String = "uses-permission"
-    override fun copy(name: String, maxSdkVersion: Int?) = Permission(name, maxSdkVersion)
+    override fun copy(name: String, maxSdkVersion: Int?, required: Boolean?) = Permission(name, maxSdkVersion)
 }
 
-internal class Sdk23Permission(name: String, maxSdkVersion: Int? = null) : BasePermission(name, maxSdkVersion) {
+internal class Sdk23Permission(name: String, maxSdkVersion: Int? = null) : BasePermission(name, maxSdkVersion, null) {
     override val tag: String = "uses-permission-sdk-23"
-    override fun copy(name: String, maxSdkVersion: Int?) = Sdk23Permission(name, maxSdkVersion)
+    override fun copy(name: String, maxSdkVersion: Int?, required: Boolean?) = Sdk23Permission(name, maxSdkVersion)
+}
+
+internal class Feature(name: String, required: Boolean? = null) : BasePermission(name, null, required) {
+    override val tag: String = "uses-feature"
+    override fun copy(name: String, maxSdkVersion: Int?, required: Boolean?) = Feature(name, required)
 }

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/report/HtmlReporter.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/report/HtmlReporter.kt
@@ -100,8 +100,8 @@ internal class HtmlReporter(private val reportFile: File) : Reporter {
         val oldPermission = when (violation) {
             is Violation.Added -> null
             is Violation.Removed -> violation.permission
-            is Violation.MaxSdkIncreased -> violation.permission.copy(maxSdkVersion = violation.from)
-            is Violation.MaxSdkDecreased -> violation.permission.copy(maxSdkVersion = violation.from)
+            is Violation.MaxSdkIncreased -> violation.permission.copy(maxSdkVersion = violation.from, required = false)
+            is Violation.MaxSdkDecreased -> violation.permission.copy(maxSdkVersion = violation.from, required = false)
         }
 
         // Removed code snippet

--- a/sample/app/sample-baseline.xml
+++ b/sample/app/sample-baseline.xml
@@ -7,6 +7,7 @@
         <uses-permission maxSdkVersion="26" name="android.permission.ACCESS_COARSE_LOCATION"/>
         <uses-permission maxSdkVersion="26" name="android.permission.ACCESS_FINE_LOCATION"/>
         <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+        <uses-feature name="android.hardware.camera.autofocus" required="false"/>
     </variant>
     <variant name="release">
         <uses-permission name="android.permission.CAMERA"/>
@@ -15,5 +16,6 @@
         <uses-permission maxSdkVersion="26" name="android.permission.ACCESS_COARSE_LOCATION"/>
         <uses-permission maxSdkVersion="26" name="android.permission.ACCESS_FINE_LOCATION"/>
         <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+        <uses-feature name="android.hardware.camera.autofocus" required="false"/>
     </variant>
 </baseline>

--- a/sample/app/src/main/AndroidManifest.xml
+++ b/sample/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.github.simonschiller.permissioncheck.sample.app">
 
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
     <uses-permission android:name="android.permission.INTERNET" android:maxSdkVersion="27"  />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="26" />


### PR DESCRIPTION
We need a check for the 'uses-feature' permissions as well as the current ones.
Uses-feature nodes have an optional "required" attribute that we also want to check it has not changed.

We could also update the README.md file with information about this in case you consider this is worth adding to the plugin.